### PR TITLE
Update HPA default value in HPA docs

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale.md
@@ -37,7 +37,7 @@ to match the observed average CPU utilization to the target specified by user.
 
 The Horizontal Pod Autoscaler is implemented as a control loop, with a period controlled
 by the controller manager's `--horizontal-pod-autoscaler-sync-period` flag (with a default
-value of 30 seconds).
+value of 15 seconds).
 
 During each period, the controller manager queries the resource utilization against the
 metrics specified in each HorizontalPodAutoscaler definition.  The controller manager


### PR DESCRIPTION
Change the default value of the following parameter
- `horizontal-pod-autoscaler-sync-period`: default value has updated to 15 from 30.